### PR TITLE
Implement butterfly effect tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/enhanced-geopolitical-sim.tsx
+++ b/enhanced-geopolitical-sim.tsx
@@ -38,6 +38,9 @@ class WorldEngine {
   recordDecision(decision, turn) {
     const effects = this.calculateCascadingEffects(decision);
     this.history.push({ turn, decision, effects, timestamp: Date.now() });
+
+    // Store subtle ripple effects for later analysis
+    this.recordButterflyEffect(turn, { decision: decision.title, effects });
     
     // Check for major divergence
     if (effects.divergenceScore > 50) {
@@ -82,6 +85,22 @@ class WorldEngine {
     });
 
     return nationActions;
+  }
+
+  // Record butterfly effect information keyed by turn
+  recordButterflyEffect(turn, effect) {
+    if (!this.butterflyEffects.has(turn)) {
+      this.butterflyEffects.set(turn, []);
+    }
+    this.butterflyEffects.get(turn).push(effect);
+  }
+
+  // Retrieve butterfly effects for a specific turn or all turns
+  getButterflyEffects(turn) {
+    if (typeof turn === 'number') {
+      return this.butterflyEffects.get(turn) || [];
+    }
+    return Array.from(this.butterflyEffects.entries()).map(([t, effects]) => ({ turn: t, effects }));
   }
 }
 


### PR DESCRIPTION
## Summary
- add method to store ripple effects in `WorldEngine`
- expose retrieval of recorded butterfly effects
- record these effects whenever decisions are made
- ignore `node_modules`

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688d1c75e42c8326a3bab125123ece23