### PR TITLE
Optimize turn analysis

### DIFF
--- a/enhanced-geopolitical-sim.tsx
+++ b/enhanced-geopolitical-sim.tsx
@@ -724,9 +724,10 @@ const AdvancedGeopoliticalSimulation = () => {
   const [detailView, setDetailView] = useState(null);
 
   // ==== ENHANCED TURN GENERATION ====
-  const generateTurnContent = useCallback((state) => {
+  const generateTurnContent = useCallback((state, precomputedAnalysis?) => {
     const scenarios = [];
-    const worldAnalysis = analyzeComplexWorldState(state);
+    // Reuse analysis if provided to avoid redundant heavy calculations
+    const worldAnalysis = precomputedAnalysis || analyzeComplexWorldState(state);
     
     // Generate scenarios based on comprehensive world analysis
     scenarios.push(...generateCrisisScenarios(state, worldAnalysis));
@@ -2048,8 +2049,9 @@ const AdvancedGeopoliticalSimulation = () => {
       return true;
     });
 
-    // Generate events and store for this turn
-    const events = generateTurnContent(newState);
+    // Generate events using a single world analysis calculation
+    const analysis = analyzeComplexWorldState(newState);
+    const events = generateTurnContent(newState, analysis);
     newState.turnEvents = events;
     if (DEBUG) console.log('Turn events:', events);
     worldEngine.state = newState;
@@ -2209,3 +2211,6 @@ const AdvancedGeopoliticalSimulation = () => {
     </div>
   );
 };
+
+export default AdvancedGeopoliticalSimulation;
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
       "dom",
       "dom.iterable"
     ]
-  }
+  },
+  "exclude": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- reuse world analysis when generating turn content
- compute analysis once per end-of-turn
- exclude Vite config from TypeScript compilation

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688d4a2dfa008326bbf9e8d91f1e60aa